### PR TITLE
An example exceptions route

### DIFF
--- a/src/main/scala/io/github/samspills/http4sbugsnagexample/ExampleExceptions.scala
+++ b/src/main/scala/io/github/samspills/http4sbugsnagexample/ExampleExceptions.scala
@@ -1,0 +1,32 @@
+package io.github.samspills.http4sbugsnagexample
+
+import cats.effect.Sync
+import cats.implicits._
+import io.circe.{Encoder, Json}
+import org.http4s.EntityEncoder
+import org.http4s.circe._
+
+trait ExampleExceptions[F[_]]{
+  def error(code: ExampleExceptions.Code): F[String]
+}
+
+case class ForbiddenExample(m: String) extends Exception(m)
+case class NotFoundExample(m: String) extends Exception(m)
+case class NotImplementedExample(m: String) extends Exception(m)
+case class UnavailableExample(m: String) extends Exception(m)
+
+object ExampleExceptions {
+  implicit def apply[F[_]](implicit ev: ExampleExceptions[F]): ExampleExceptions[F] = ev
+  final case class Code(value: Int) extends AnyVal
+  def impl[F[_]](implicit F: Sync[F]): ExampleExceptions[F] = new ExampleExceptions[F]{
+    def error(code: ExampleExceptions.Code): F[String] = {
+      code.value match {
+      case 200 => "all good".pure[F]
+      case 403 => F.raiseError(new ForbiddenExample("403 forbidden example"))
+      case 501 => F.raiseError(new NotImplementedExample("501 not implemented example"))
+      case 503 => F.raiseError(new UnavailableExample("503 unavailable example"))
+      case _ => F.raiseError(new NotFoundExample("not found catch all"))
+    }
+  }
+  }
+}

--- a/src/main/scala/io/github/samspills/http4sbugsnagexample/Http4sbugsnagexampleRoutes.scala
+++ b/src/main/scala/io/github/samspills/http4sbugsnagexample/Http4sbugsnagexampleRoutes.scala
@@ -30,4 +30,13 @@ object Http4sbugsnagexampleRoutes {
         } yield resp
     }
   }
+
+  def exceptionRoutes[F[_]: Sync](E: ExampleExceptions[F]): HttpRoutes[F] = {
+    val dsl = new Http4sDsl[F]{}
+    import dsl._
+    HttpRoutes.of[F] {
+      case GET -> Root / "exception" / IntVar(code) => 
+        Ok(E.error(ExampleExceptions.Code(code)))
+    }
+  }
 }

--- a/src/main/scala/io/github/samspills/http4sbugsnagexample/Http4sbugsnagexampleRoutes.scala
+++ b/src/main/scala/io/github/samspills/http4sbugsnagexample/Http4sbugsnagexampleRoutes.scala
@@ -36,7 +36,12 @@ object Http4sbugsnagexampleRoutes {
     import dsl._
     HttpRoutes.of[F] {
       case GET -> Root / "exception" / IntVar(code) => 
-        Ok(E.error(ExampleExceptions.Code(code)))
+        Ok(E.error(ExampleExceptions.Code(code))).handleErrorWith {
+          case ForbiddenExample(m) => Forbidden(m)
+          case NotFoundExample(m) => NotFound(m)
+          case NotImplementedExample(m) => NotImplemented(m)
+          case UnavailableExample(m) => ServiceUnavailable(m)
+        }
     }
   }
 }

--- a/src/main/scala/io/github/samspills/http4sbugsnagexample/Http4sbugsnagexampleServer.scala
+++ b/src/main/scala/io/github/samspills/http4sbugsnagexample/Http4sbugsnagexampleServer.scala
@@ -16,6 +16,7 @@ object Http4sbugsnagexampleServer {
       client <- BlazeClientBuilder[F](global).stream
       helloWorldAlg = HelloWorld.impl[F]
       jokeAlg = Jokes.impl[F](client)
+      exampleExceptionsAlg = ExampleExceptions.impl[F]
 
       // Combine Service Routes into an HttpApp.
       // Can also be done via a Router if you
@@ -23,7 +24,8 @@ object Http4sbugsnagexampleServer {
       // in the underlying routes.
       httpApp = (
         Http4sbugsnagexampleRoutes.helloWorldRoutes[F](helloWorldAlg) <+>
-        Http4sbugsnagexampleRoutes.jokeRoutes[F](jokeAlg)
+          Http4sbugsnagexampleRoutes.jokeRoutes[F](jokeAlg) <+>
+          Http4sbugsnagexampleRoutes.exceptionRoutes[F](exampleExceptionsAlg)
       ).orNotFound
 
       // With Middlewares in place


### PR DESCRIPTION
Adds an example route that raises exceptions based on a status code path parameter.

2nd commit adds error handling to the route. This isn't necessary for bugsnag to do things but I think adding the error message to the `Response` makes things a bit easier to reason about later. Also it allows us to map from the exception raised to a response type, which will be helpful later on. 